### PR TITLE
big changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.3
+  - 1.5
   - nightly
 matrix:
   allow_failures:

--- a/src/MeasureTheory.jl
+++ b/src/MeasureTheory.jl
@@ -9,8 +9,9 @@ const EmptyNamedTuple = NamedTuple{(),Tuple{}}
 
 
 export ≪
+export sampletype
 
-abstract type AbstractMeasure{X} end
+abstract type AbstractMeasure end
 
 """
     logdensity(μ::Measure{X}, x::X)
@@ -23,26 +24,15 @@ Methods for computing density relative to other measures will be
 """
 function logdensity end
 
-
-Base.eltype(μ::AbstractMeasure{X}) where {X} = X
-
-
-
-logdensity(μ::Dists.Distribution, x) = Dists.logpdf(μ,x)
-
-density(μ::Dists.Distribution, x) = Dists.pdf(μ,x)
-
-
 include("absolutecontinuity.jl")
-include("basemeasures/lebesgue.jl")
+include("basemeasures.jl")
 include("macros.jl")
 include("combinators/scale.jl")
 include("combinators/superpose.jl")
 include("combinators/product.jl")
 include("distributions.jl")
-# include("probability/normal.jl")
+include("probability/normal.jl")
 include("density.jl")
-
-
+include("pushforward.jl")
 
 end # module

--- a/src/absolutecontinuity.jl
+++ b/src/absolutecontinuity.jl
@@ -23,3 +23,21 @@ Note that this is often written `~` in the literature, but this is overloaded in
 function ≃(μ,ν)
     return (μ≪ν && ν≪μ)
 end
+
+export representative
+
+function representative(μ)
+    # Check if we're done
+    isprimitive(μ) && return μ
+
+    ν = baseMeasure(μ)
+    
+    # Make sure not to leave the equivalence class
+    (ν ≪ μ) || return μ
+
+    # Fall back on a recusive call
+    return representative(ν)
+end
+
+
+≪(μ, ν) = representative(μ) ≪ representative(ν)

--- a/src/basemeasures.jl
+++ b/src/basemeasures.jl
@@ -1,0 +1,9 @@
+"""
+    baseMeasure(μ)
+
+
+"""
+function baseMeasure end
+
+include("basemeasures/trivial.jl")
+include("basemeasures/lebesgue.jl")

--- a/src/basemeasures/basemeasures.jl
+++ b/src/basemeasures/basemeasures.jl
@@ -1,0 +1,6 @@
+"""
+    baseMeasure(μ)
+
+
+"""
+function baseMeasure end

--- a/src/basemeasures/lebesgue.jl
+++ b/src/basemeasures/lebesgue.jl
@@ -1,8 +1,13 @@
 # Lebesgue measure
 
 export Lebesgue
-struct Lebesgue{X} <: AbstractMeasure{X} end
+struct Lebesgue{X} <: AbstractMeasure end
 
 Lebesgue(X) = Lebesgue{X}()
 
 baseMeasure(μ::Lebesgue{X}) where {X} = μ
+
+isprimitive(::Lebesgue) = true
+isprimitive(μ) = false
+
+sampletype(::Lebesgue{X}) where{X} = X

--- a/src/basemeasures/trivial.jl
+++ b/src/basemeasures/trivial.jl
@@ -1,3 +1,5 @@
-struct TrivialMeasure{X} <: AbstractMeasure{X} end
+export TrivialMeasure
 
-TrivialMeasure(X) = TrivialMeasure{X}()
+struct TrivialMeasure <: AbstractMeasure end
+
+sampletype(::TrivialMeasure) = Nothing

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -27,7 +27,7 @@ function Base.:*(μ::ProductMeasure{X}, ν) where {X}
     ProductMeasure(components...)
 end
 
-function Base.:*(μ, ν)
+function Base.:*(μ::M, ν::N) where {M <: AbstractMeasure, N <: AbstractMeasure}
     components = (μ, ν)
     ProductMeasure(components...)
 end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -1,11 +1,10 @@
 export ProductMeasure
 using Base: eltype
 
-struct ProductMeasure{T} <: AbstractMeasure{T}
-    # TODO: Type annotation
-    components
+struct ProductMeasure{T}
+    components :: T
 
-    ProductMeasure(μs...) = new{Tuple{eltype.(μs)...}}(μs)
+    ProductMeasure(μs...) = new{Tuple{sampletype.(μs)...}}(μs)
 end
 
 
@@ -18,26 +17,23 @@ function Base.:*(μ::ProductMeasure{X}, ν::ProductMeasure{Y}) where {X,Y}
     ProductMeasure(components...)
 end
 
-function Base.:*(μ::AbstractMeasure{X}, ν::ProductMeasure{Y}) where {X,Y}
+function Base.:*(μ, ν::ProductMeasure{Y}) where {Y}
     components = (μ, ν.components...)
     ProductMeasure(components...)
 end
 
-function Base.:*(μ::ProductMeasure{X}, ν::AbstractMeasure{Y}) where {X,Y}
+function Base.:*(μ::ProductMeasure{X}, ν) where {X}
     components = (μ.components..., ν)
     ProductMeasure(components...)
 end
 
-function Base.:*(μ::AbstractMeasure{X}, ν::AbstractMeasure{Y}) where {X,Y}
+function Base.:*(μ, ν) where {X,Y}
     components = (μ, ν)
     ProductMeasure(components...)
-end
-
-export × 
-function ×(μ::AbstractMeasure{X}, ν::AbstractMeasure{Y}) where {X,Y}
-    return μ*ν
 end
 
 function Base.rand(μ::ProductMeasure{T}) where T
     return rand.(μ.components)
 end
+
+sampletype(μ::ProductMeasure) = Tuple{sampletype.(μ.components)...}

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -27,7 +27,7 @@ function Base.:*(μ::ProductMeasure{X}, ν) where {X}
     ProductMeasure(components...)
 end
 
-function Base.:*(μ, ν) where {X,Y}
+function Base.:*(μ, ν)
     components = (μ, ν)
     ProductMeasure(components...)
 end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -1,7 +1,7 @@
 export ProductMeasure
 using Base: eltype
 
-struct ProductMeasure{T}
+struct ProductMeasure{T} <: AbstractMeasure
     components :: T
 
     ProductMeasure(μs...) = new{Tuple{sampletype.(μs)...}}(μs)

--- a/src/combinators/scale.jl
+++ b/src/combinators/scale.jl
@@ -1,29 +1,33 @@
 """
-    struct ScaledMeasure{R,M,X} <: AbstractMeasure{X}
+    struct ScaledMeasure{R,M} <: AbstractMeasure
         logscale :: R
         base :: M
     end
     
 
 """
-struct ScaledMeasure{R,M,X} <: AbstractMeasure{X}
+struct ScaledMeasure{R,M} 
     logscale :: R
     base :: M
 end
 
-function logdensity(sm::ScaledMeasure{R,M,X}, x::X) where {X, R <: Real, M <: AbstractMeasure{X}}
+function logdensity(sm::ScaledMeasure{R,M}, x::X) where {X, R, M <: AbstractMeasure}
     logdensity(sm.base, x) + sm.logscale
 end
 
-function Base.:*(k::Number, m::AbstractMeasure{X}) where {X} 
+function Base.:*(k::Number, m::AbstractMeasure) 
     if iszero(k)
-        return TrivialMeasure(X)
+        return TrivialMeasure
     else
-        return ScaledMeasure{typeof(k), typeof(m),X}(log(k),m)
+        return ScaledMeasure{typeof(k), typeof(m)}(log(k),m)
     end
 end
 
-Base.:*(m::AbstractMeasure{X}, k::Real) where {X} = k * m
+Base.:*(m::AbstractMeasure, k::Real) = k * m
 
-≪(::M, ::ScaledMeasure{R,M,X}) where {R,M,X} = true
-≪(::ScaledMeasure{R,M,X}, ::M) where {R,M,X} = true
+≪(::M, ::ScaledMeasure{R,M}) where {R,M,X} = true
+≪(::ScaledMeasure{R,M}, ::M) where {R,M,X} = true
+
+baseMeasure(μ::ScaledMeasure{R,M}) where {R,M,X} = μ.base
+
+sampletype(μ:: ScaledMeasure) = sampletype(μ.base)

--- a/src/combinators/scale.jl
+++ b/src/combinators/scale.jl
@@ -25,9 +25,9 @@ end
 
 Base.:*(m::AbstractMeasure, k::Real) = k * m
 
-≪(::M, ::ScaledMeasure{R,M}) where {R,M,X} = true
-≪(::ScaledMeasure{R,M}, ::M) where {R,M,X} = true
+≪(::M, ::ScaledMeasure{R,M}) where {R,M} = true
+≪(::ScaledMeasure{R,M}, ::M) where {R,M} = true
 
-baseMeasure(μ::ScaledMeasure{R,M}) where {R,M,X} = μ.base
+baseMeasure(μ::ScaledMeasure{R,M}) where {R,M} = μ.base
 
 sampletype(μ:: ScaledMeasure) = sampletype(μ.base)

--- a/src/combinators/scale.jl
+++ b/src/combinators/scale.jl
@@ -6,7 +6,7 @@
     
 
 """
-struct ScaledMeasure{R,M} 
+struct ScaledMeasure{R,M} <: AbstractMeasure
     logscale :: R
     base :: M
 end

--- a/src/combinators/superpose.jl
+++ b/src/combinators/superpose.jl
@@ -1,7 +1,7 @@
 export SuperpositionMeasure
 
 """
-    struct SuperpositionMeasure{X,NT} <: AbstractMeasure{X}
+    struct SuperpositionMeasure{X,NT} <: AbstractMeasure
         components :: NT
     end
 
@@ -10,11 +10,11 @@ measures need not be normalized) requires no scaling.
 
 The superposition of two measures μ and ν can be more concisely written as μ + ν.
 """
-struct SuperpositionMeasure{X,NT} <: AbstractMeasure{X}
+struct SuperpositionMeasure{X,NT} <: AbstractMeasure
     components :: NT   
 end
 
-SuperpositionMeasure(ms :: AbstractMeasure{X}...) where {X} = SuperpositionMeasure{X,length(ms)}(ms)
+SuperpositionMeasure(ms :: AbstractMeasure...) where {X} = SuperpositionMeasure{X,length(ms)}(ms)
 
 # SuperpositionMeasure(m::NTuple{N, Measure{X}}) where {N,X} = SuperpositionMeasure(m...)
 
@@ -25,17 +25,17 @@ function Base.:+(μ::SuperpositionMeasure{X,N1}, ν::SuperpositionMeasure{X,N2})
     SuperpositionMeasure{X, N1+N2}(components)
 end
 
-function Base.:+(μ::AbstractMeasure{X}, ν::SuperpositionMeasure{X,N}) where {X,N}
+function Base.:+(μ::AbstractMeasure, ν::SuperpositionMeasure{X,N}) where {X,N}
     components = (μ, ν.components...)
     SuperpositionMeasure{X,N+1}(components)
 end
 
-function Base.:+(μ::SuperpositionMeasure{X,N}, ν::AbstractMeasure{X}) where {X,N}
+function Base.:+(μ::SuperpositionMeasure{X,N}, ν::AbstractMeasure) where {X,N}
     components = (μ.components..., ν)
     SuperpositionMeasure{X,N+1}(components)
 end
 
-function Base.:+(μ::AbstractMeasure{X}, ν::AbstractMeasure{X}) where {X}
+function Base.:+(μ::AbstractMeasure, ν::AbstractMeasure) where {X}
     components = (μ, ν)
     SuperpositionMeasure{X,2}(components)
 end

--- a/src/combinators/superpose.jl
+++ b/src/combinators/superpose.jl
@@ -40,6 +40,7 @@ function Base.:+(μ::AbstractMeasure, ν::AbstractMeasure) where {X}
     SuperpositionMeasure{X,2}(components)
 end
 
-function Base.rand(μ::SuperpositionMeasure{X,N}) where {X,N}
-    return rand(rand(μ.components))
-end
+# TODO: Fix `rand` method (this one is wrong)
+# function Base.rand(μ::SuperpositionMeasure{X,N}) where {X,N}
+#     return rand(rand(μ.components))
+# end

--- a/src/density.jl
+++ b/src/density.jl
@@ -12,13 +12,13 @@ Because this function is often difficult to express in closed form, there are
 many different ways of computing it. We therefore provide a formal
 representation to allow comptuational flexibilty.
 """
-struct Density{M,B}
+struct Density{M,B} <: Function
     μ::M
     base::B
 end
 
 """
-    struct DensityMeasure{F,B} <: AbstractMeasure{X}
+    struct DensityMeasure{F,B} <: AbstractMeasure
         density :: F
         base    :: B
     end
@@ -26,7 +26,7 @@ end
 A `DensityMeasure` is a measure defined by a density with respect to some other
 "base" measure 
 """
-struct DensityMeasure{X,F,B} <: AbstractMeasure{X}
+struct DensityMeasure{X,F,B} <: AbstractMeasure
     density :: F
     base    :: B
 end
@@ -37,12 +37,12 @@ end
 #     end
 # end
 
-density(μ, base=basemeasure(μ)) = Density(μ, base)
-logdensity(μ, base=basemeasure(μ)) = LogDensity(μ, base)
+density(μ, base=baseMeasure(μ)) = Density(μ, base)
+logdensity(μ, base=baseMeasure(μ)) = LogDensity(μ, base)
 
 density(μ::Dists.Distribution{Dists.Univariate,Dists.Continuous}, x::Real) = pdf(μ,x)
 logdensity(μ::Dists.Distribution{Dists.Univariate,Dists.Continuous}, x::Real) = logpdf(μ,x)
 
-density(μ::AbstractMeasure{X}, x::X) where {X} = density(μ, baseMeasure(μ))(x) 
+density(μ::AbstractMeasure, x::X) where {X} = density(μ, baseMeasure(μ))(x) 
 
-logdensity(μ::AbstractMeasure{X}, y::Y) where {X, Y <: X} = logdensity(μ, baseMeasure(μ))(x)
+logdensity(μ::AbstractMeasure, y::Y) where {X, Y <: X} = logdensity(μ, baseMeasure(μ))(x)

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -9,7 +9,7 @@ function Measure(dist::Dists.Distribution{F,S}) where {F,S}
     DistributionMeasure{F,S,X}(dist)
 end
 
-struct DistributionMeasure{F, S, X} <: AbstractMeasure{X}
+struct DistributionMeasure{F, S, X} <: AbstractMeasure
     dist :: Dists.Distribution{F, S}
 end
 
@@ -22,8 +22,6 @@ export logdensity
 function logdensity(μ::DistributionMeasure{F,S,X}, x::X) where {F, S, X}
     return Dists.logpdf(μ.dist, x)
 end
-
-export rand
 
 function Base.rand(μ::DistributionMeasure{F,S,X}) where {F, S, X}
     return rand(μ.dist)
@@ -43,3 +41,7 @@ function baseMeasure(μ::Dists.Distribution{Dists.Multivariate,Dists.Continuous}
     x = rand(μ)
     return Lebesgue(typeof(x))
 end
+
+logdensity(μ::Dists.Distribution, x) = Dists.logpdf(μ,x)
+
+density(μ::Dists.Distribution, x) = Dists.pdf(μ,x)

--- a/src/probability/dirac.jl
+++ b/src/probability/dirac.jl
@@ -1,13 +1,13 @@
 
 export Dirac
 
-struct Dirac{X} <: AbstractMeasure{X}
+struct Dirac{X} <: AbstractMeasure
     supp :: X
 end
 
 Dirac(x::X) = Dirac{X}(x)
 
-eltype(μ::Dirac{X}) = X
+sampletype(μ::Dirac{X}) = X
 
 function (μ::Dirac{X})(s) where {X}
     μ.supp ∈ s && return 1
@@ -18,3 +18,5 @@ function logdensity(μ::Dirac{X}, x::X)
     μ.supp ∈ s && return 0.0
     return -Inf
 end
+
+Base.rand(μ::Dirac) = μ.supp

--- a/src/probability/normal.jl
+++ b/src/probability/normal.jl
@@ -6,88 +6,25 @@ export Normal
 
 import Base: eltype
 
-# Note: `@measure Normal Lebesgue` expands to (cleaned up)
-
-# quote
-#     struct Normal{P, X} <: AbstractMeasure{X}
-#         par::P
-#     end
-
-#     function Normal(nt::NamedTuple)
-#         P = typeof(nt)
-#         return Normal{P, eltype(Normal{P})}
-#     end
-    
-#     Normal(; kwargs...) = Normal((; kwargs...))
-    
-#     (baseMeasure(μ::Normal{P, X}) where {P, X}) = Lebesgue{X}
-            
-#     (:≪(::Normal{P, X}, ::Lebesgue{X}) where {P, X}) = true
-
-# end
-# @measure Normal Lebesgue
-
 
 @measure Normal(μ,σ) ≃ (1/sqrt2π) * Lebesgue(X)
 
 
 function logdensity(d::Normal{P} , x::X) where {P <: NamedTuple{(:μ, :σ)}, X}    
-    return - (log(2) + log(π)) / 2 - log(d.par.σ)  - (x - d.par.μ)^2 / (2 * d.par.σ^2)
+    return - log(d.par.σ)  - (x - d.par.μ)^2 / (2 * d.par.σ^2)
 end
 
 # Standard normal
 
-function logdensity(d::Normal{EmptyNamedTuple,X} , ::Lebesgue{X}) where {X <: Real}    
-    return - (log(2) + log(π)) / 2  - x^2 / 2 
+function logdensity(d::Normal{EmptyNamedTuple} , x::X) where {X}  
+    return - x^2 / 2 
 end
 
-Normal() = Normal(NamedTuple())
+# Normal() = Normal{EmptyNamedTuple,Real}(NamedTuple())
  
-# @implement HasDensity{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :σ)}} begin
-#     baseMeasure(d) = Lebesgue(X)
-#     logdensity(d, x) = - (log(2) + log(π)) / 2 - log(d.par.σ)  - (x - d.par.μ)^2 / (2 * d.par.σ^2)
-# end
+sampletype(::NamedTuple{(),Tuple{}}) = Real
 
-# # μ, τ
+Base.rand(μ::Normal{EmptyNamedTuple}) = randn()
 
-# eltype(::Type{Normal}, ::Type{NamedTuple{(:μ, :τ), Tuple{A, B}}}) where {A,B} = promote_type(A,B)
-
-# @implement HasDensity{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :τ)}} begin
-#     baseMeasure(d) = Lebesgue(X)
-#     logdensity(d, x) = - (log(2) + log(π) - log(d.par.τ)  + d.par.τ * (x - d.par.μ)^2) / 2
-# end
-
-
-# # σ
-
-
-# eltype(::Type{Normal}, ::Type{NamedTuple{(:σ,), Tuple{B}}}) where {B} = B
-
-
-# @implement HasDensity{Normal{P,X},X} where {X, P <: NamedTuple{(:σ,)}} begin
-#     baseMeasure(d) = Lebesgue(X)
-#     logdensity(d, x) = - (log(2) + log(π)) / 2 - log(d.par.σ)  - x^2 / (2 * d.par.σ^2)
-# end
-
-# # τ
-
-# eltype(::Type{Normal}, ::Type{NamedTuple{(:τ,), Tuple{B}}}) where {B} = B
-
-# @implement HasDensity{Normal{P,X},X} where {X, P <: NamedTuple{(:τ,)}} begin
-#     baseMeasure(d) = Lebesgue(X)
-#     logdensity(d, x) = - (log(2) + log(π) - log(d.par.τ)  + d.par.τ * x^2) / 2
-# end
-
-# @implement HasRand{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :σ)}} begin
-#     rand(d) = Distributions.rand(Normal(d.par.μ,d.par.σ))
-# end
-
-
-# @implement IsMeasurable{Normal{P,X},S,X} where {X <: Real, S <: Interval{X}, P <: NamedTuple{(:μ, :σ)}} begin
-#     measure(d, i) = StatsFuns.normcdf(d.par.μ, d.par.σ, i.last) - StatsFuns.normcdf(d.par.μ, d.par.σ, i.first)
-# end
-
-# logdensity(Normal(σ=0.5), 4.0) 
-#  == logdensity(Normal(μ=0.0, σ=0.5), 4.0) 
-#  == logdensity(Normal(μ=0.0, τ=4.0), 4.0) 
-#  == logdensity(Normal(τ=4.0), 4.0)
+≪(::Normal, ::Lebesgue{X}) where X <: Real = true
+representative(::Normal) = Lebesgue(Real)

--- a/src/probability/normal.jl
+++ b/src/probability/normal.jl
@@ -22,7 +22,7 @@ end
 
 # Normal() = Normal{EmptyNamedTuple,Real}(NamedTuple())
  
-sampletype(::NamedTuple{(),Tuple{}}) = Real
+sampletype(::Normal{NamedTuple{(),Tuple{}}}) = Real
 
 Base.rand(μ::Normal{EmptyNamedTuple}) = randn()
 

--- a/src/pushforward.jl
+++ b/src/pushforward.jl
@@ -1,8 +1,39 @@
-struct PushForward{F,M}
+export PushForward
+
+import Bijectors
+import Base
+
+struct PushForward{F,M} <: AbstractMeasure
     f::F
     μ::M
 end
 
-import Base
+function logdensity(d::PushForward{F,M}, y) where {F <: Bijectors.Bijector, M}
+    res = Bijectors.forward(inv(d.f), y)
+    return logdensity(d.μ, res.rv) + res.logabsdetjac
+end
 
-Base.broadcast(f::Function, μ::Measure) = PushForward(f,μ)
+for F in [
+      Bijectors.ADBijector
+    , Bijectors.Composed
+    , Bijectors.Exp
+    , Bijectors.Identity
+    , Bijectors.Inverse
+    , Bijectors.InvertibleBatchNorm
+    , Bijectors.Log
+    , Bijectors.Logit
+    , Bijectors.PDBijector
+    , Bijectors.Permute
+    , Bijectors.PlanarLayer
+    , Bijectors.RadialLayer
+    , Bijectors.Scale
+    , Bijectors.Shift
+    , Bijectors.SimplexBijector
+    , Bijectors.Stacked
+    , Bijectors.TruncatedBijector] 
+    @eval (f::$F)(μ::M) where {M <: AbstractMeasure} = PushForward(f,μ)
+end
+
+
+
+Base.rand(d::PushForward) = d.f(rand(d.μ))


### PR DESCRIPTION
Lots of changes here:

- Added `sampletype`, as suggested by @phipsgabler (`eltype` doesn't cut it)
- Removed the `X` type parameter in a few places (`AbstractMeasure`, `TrivialMeasure`, parameterized measures)
- Started a `basemeasures.jl` to define what a `baseMeasure` is and import things
- Added `representative`, i.e., of the equivalence class wrt absolute continuity. In general this is different than a base measure
- Added `isprimitive`, which just indicates a measure is not defined in terms of others
- Removed `×` for measures, as @sethaxen pointed out it clashes with `LinearAlgebra.×`, and @mschauer that \otimes is more standard
- Made `Density <: Function`, because why not
- Added support for `PushForward` in terms of `Bijectors`