### PR TITLE
Make @measure more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ quote
             Normal((; var"#14#kwargs"...))
         end
     #= /home/chad/git/Measures.jl/src/Measures.jl:66 =#
-    (var"#8#baseMeasure"(var"#15#μ"::Normal{var"#16#P", var"#17#X"}) where {var"#16#P", var"#17#X"}) = begin
+    (var"#8#basemeasure"(var"#15#μ"::Normal{var"#16#P", var"#17#X"}) where {var"#16#P", var"#17#X"}) = begin
             #= /home/chad/git/Measures.jl/src/Measures.jl:66 =#
             Lebesgue{var"#17#X"}
         end
@@ -138,7 +138,7 @@ That's still kind of boring, so let's build the density. For this, we need to im
 
 ```julia
 @trait Density{M,X} where {X = domain{M}} begin
-    baseMeasure :: [M] => Measure{X}
+    basemeasure :: [M] => Measure{X}
     logdensity :: [M, X] => Real
 end
 ```
@@ -146,8 +146,8 @@ end
 A density doesn't exist by itself, but is defined relative to some _base measure_. For a normal distribution this is just Lebesgue measure on the real numbers. That, together with the usual Gaussian log-density, gives us
 
 ```julia
-@implement Density{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :σ)}} begin
-    baseMeasure(d) = Lebesgue(X)
+@implement Density{Normal{X,P},X} where {X, P <: NamedTuple{(:μ, :σ)}} begin
+    basemeasure(d) = Lebesgue(X)
     logdensity(d, x) = - (log(2) + log(π)) / 2 - log(d.par.σ)  - (x - d.par.μ)^2 / (2 * d.par.σ^2)
 end
 ```
@@ -171,8 +171,8 @@ What about other parameterizations? Sure, no problem. Here's a way to write this
 ```julia
 eltype(::Type{Normal}, ::Type{NamedTuple{(:μ, :τ), Tuple{A, B}}}) where {A,B} = promote_type(A,B)
 
-@implement Density{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :τ)}} begin
-    baseMeasure(d) = Lebesgue(X)
+@implement Density{Normal{X,P},X} where {X, P <: NamedTuple{(:μ, :τ)}} begin
+    basemeasure(d) = Lebesgue(X)
     logdensity(d, x) = - (log(2) + log(π) - log(d.par.τ)  + d.par.τ * (x - d.par.μ)^2) / 2
 end
 ```

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -44,3 +44,5 @@ function Base.rand(d::PowerMeasure)
     result = Array{sampletype(d.μ), length(d.size)}(undef, d.size...)
     return rand!(result, d)
 end    
+
+basemeasure(μ::PowerMeasure) = basemeasure(μ.μ)^μ.size

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -14,7 +14,7 @@ Note that power measures are only well-defined for integer powers.
 
 The nth power of a measure μ can be written μ^x.
 """
-struct PowerMeasure{M,N}
+struct PowerMeasure{M,N} <: AbstractMeasure
     μ::M
     size::NTuple{N,Int}
 end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -5,6 +5,7 @@ struct ProductMeasure{T} <: AbstractMeasure
     components :: T
 
     ProductMeasure(μs...) = new{typeof(μs)}(μs)
+    ProductMeasure(μs) = new{typeof(μs)}(μs)
 end
 
 
@@ -37,3 +38,5 @@ function Base.rand(μ::ProductMeasure{T}) where T
 end
 
 sampletype(μ::ProductMeasure) = Tuple{sampletype.(μ.components)...}
+
+basemeasure(μ::ProductMeasure) = ProductMeasure(basemeasure.(μ.components))

--- a/src/probability/normal.jl
+++ b/src/probability/normal.jl
@@ -7,7 +7,7 @@ export Normal
 import Base: eltype
 
 
-@measure Normal(μ,σ) ≃ (1/sqrt2π) * Lebesgue(X)
+@measure Normal(μ,σ) ≃ (1/sqrt2π) * Lebesgue(Real)
 
 
 function logdensity(d::Normal{P} , x::X) where {P <: NamedTuple{(:μ, :σ)}, X}    


### PR DESCRIPTION
Made it so things like this now work:

```julia
julia> using MeasureTheory

julia> using MacroTools

julia> using StatsFuns

julia> @measure MvNormal(μ,Σ) ≃ (1/sqrt2π^length(μ)) * Lebesgue(Real)^size(μ);

julia> prettify(@macroexpand @measure MvNormal(μ,Σ) ≃ (1/sqrt2π^length(μ)) * Lebesgue(Real)^size(μ))
quote
    struct MvNormal{P} <: MeasureTheory.AbstractMeasure
        par::P
    end
    function MvNormal(nt::NamedTuple)
        P = typeof(nt)
        return MvNormal{P}(nt)
    end
    MvNormal(; kwargs...) = MvNormal((; kwargs...))
    function MeasureTheory.basemeasure(μ::MvNormal{P}) where P
        return (1 / sqrt2π ^ length(μ.par.μ)) * Lebesgue(Real) ^ size(μ.par.μ)
    end
    MvNormal(μ, Σ) = MvNormal(; μ, Σ)
end

julia> μ = randn(3);

julia> Σ = let x = randn(10,3)
           x' * x
       end;

julia> basemeasure(MvNormal(μ, Σ))
MeasureTheory.ScaledMeasure{Float64,PowerMeasure{Lebesgue{Real},1}}(-2.7568155996140185, PowerMeasure{Lebesgue{Real},1}(Lebesgue{Real}(), (3,)))
```

Currently I'm just escaping the whole thing, we'll need another pass once we have it working properly to make things more hygienic.