### PR TITLE
`show` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ quote
             Normal((; var"#14#kwargs"...))
         end
     #= /home/chad/git/Measures.jl/src/Measures.jl:66 =#
-    (var"#8#baseMeasure"(var"#15#μ"::Normal{var"#16#P", var"#17#X"}) where {var"#16#P", var"#17#X"}) = begin
+    (var"#8#basemeasure"(var"#15#μ"::Normal{var"#16#P", var"#17#X"}) where {var"#16#P", var"#17#X"}) = begin
             #= /home/chad/git/Measures.jl/src/Measures.jl:66 =#
             Lebesgue{var"#17#X"}
         end
@@ -138,7 +138,7 @@ That's still kind of boring, so let's build the density. For this, we need to im
 
 ```julia
 @trait Density{M,X} where {X = domain{M}} begin
-    baseMeasure :: [M] => Measure{X}
+    basemeasure :: [M] => Measure{X}
     logdensity :: [M, X] => Real
 end
 ```
@@ -146,8 +146,8 @@ end
 A density doesn't exist by itself, but is defined relative to some _base measure_. For a normal distribution this is just Lebesgue measure on the real numbers. That, together with the usual Gaussian log-density, gives us
 
 ```julia
-@implement Density{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :σ)}} begin
-    baseMeasure(d) = Lebesgue(X)
+@implement Density{Normal{X,P},X} where {X, P <: NamedTuple{(:μ, :σ)}} begin
+    basemeasure(d) = Lebesgue(X)
     logdensity(d, x) = - (log(2) + log(π)) / 2 - log(d.par.σ)  - (x - d.par.μ)^2 / (2 * d.par.σ^2)
 end
 ```
@@ -171,8 +171,8 @@ What about other parameterizations? Sure, no problem. Here's a way to write this
 ```julia
 eltype(::Type{Normal}, ::Type{NamedTuple{(:μ, :τ), Tuple{A, B}}}) where {A,B} = promote_type(A,B)
 
-@implement Density{Normal{P,X},X} where {X, P <: NamedTuple{(:μ, :τ)}} begin
-    baseMeasure(d) = Lebesgue(X)
+@implement Density{Normal{X,P},X} where {X, P <: NamedTuple{(:μ, :τ)}} begin
+    basemeasure(d) = Lebesgue(X)
     logdensity(d, x) = - (log(2) + log(π) - log(d.par.τ)  + d.par.τ * (x - d.par.μ)^2) / 2
 end
 ```

--- a/src/basemeasures/lebesgue.jl
+++ b/src/basemeasures/lebesgue.jl
@@ -3,6 +3,8 @@
 export Lebesgue
 struct Lebesgue{X} <: AbstractMeasure end
 
+Base.show(io::IO, μ::Lebesgue{X}) where X = print(io, "Lebesgue(", X, ")")
+
 Lebesgue(X) = Lebesgue{X}()
 
 basemeasure(μ::Lebesgue{X}) where {X} = μ

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -23,6 +23,17 @@ import Base
 
 Base.show(io::IO, μ::PowerMeasure) = print(io, μ.μ, " ^ ", μ.size)
 
+function Base.show_unquoted(io::IO, μ::ProductMeasure, indent::Int, prec::Int)
+    if Base.operator_precedence(:^) ≤ prec
+        print(io, "(")
+        show(io, μ)
+        print(io, ")")
+    else
+        show(io, μ)
+    end
+    return nothing
+end
+
 function Base.:^(μ::AbstractMeasure, n::Integer)  
     PowerMeasure(μ, (n,))
 end

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -44,3 +44,5 @@ function Base.rand(d::PowerMeasure)
     result = Array{sampletype(d.μ), length(d.size)}(undef, d.size...)
     return rand!(result, d)
 end    
+
+basemeasure(μ::PowerMeasure) = basemeasure(μ.μ)^μ.size

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -14,7 +14,7 @@ Note that power measures are only well-defined for integer powers.
 
 The nth power of a measure μ can be written μ^x.
 """
-struct PowerMeasure{M,N}
+struct PowerMeasure{M,N} <: AbstractMeasure
     μ::M
     size::NTuple{N,Int}
 end

--- a/src/combinators/power.jl
+++ b/src/combinators/power.jl
@@ -21,6 +21,8 @@ end
 
 import Base
 
+Base.show(io::IO, μ::PowerMeasure) = print(io, μ.μ, " ^ ", μ.size)
+
 function Base.:^(μ::AbstractMeasure, n::Integer)  
     PowerMeasure(μ, (n,))
 end

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -8,8 +8,7 @@ struct ProductMeasure{T} <: AbstractMeasure
     ProductMeasure(μs) = new{typeof(μs)}(μs)
 end
 
-# TODO
-# Base.show(io::IO, μ::ProductMeasure) = ...
+Base.show(io::IO, μ::ProductMeasure) = print(io, join(string.(μ.components), " ⊗ "))
 
 # ProductMeasure(m::NTuple{N, Measure{X}}) where {N,X} = ProductMeasure(m...)
 

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -10,6 +10,17 @@ end
 
 Base.show(io::IO, μ::ProductMeasure) = print(io, join(string.(μ.components), " ⊗ "))
 
+function Base.show_unquoted(io::IO, μ::ProductMeasure, indent::Int, prec::Int)
+    if Base.operator_precedence(:*) ≤ prec
+        print(io, "(")
+        show(io, μ)
+        print(io, ")")
+    else
+        show(io, μ)
+    end
+    return nothing
+end
+
 # ProductMeasure(m::NTuple{N, Measure{X}}) where {N,X} = ProductMeasure(m...)
 
 Base.length(m::ProductMeasure{T}) where {T} = length(m.components)

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -8,6 +8,8 @@ struct ProductMeasure{T} <: AbstractMeasure
     ProductMeasure(μs) = new{typeof(μs)}(μs)
 end
 
+# TODO
+# Base.show(io::IO, μ::ProductMeasure) = ...
 
 # ProductMeasure(m::NTuple{N, Measure{X}}) where {N,X} = ProductMeasure(m...)
 

--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -5,6 +5,7 @@ struct ProductMeasure{T} <: AbstractMeasure
     components :: T
 
     ProductMeasure(μs...) = new{typeof(μs)}(μs)
+    ProductMeasure(μs) = new{typeof(μs)}(μs)
 end
 
 
@@ -37,3 +38,5 @@ function Base.rand(μ::ProductMeasure{T}) where T
 end
 
 sampletype(μ::ProductMeasure) = Tuple{sampletype.(μ.components)...}
+
+basemeasure(μ::ProductMeasure) = ProductMeasure(basemeasure.(μ.components))

--- a/src/combinators/scale.jl
+++ b/src/combinators/scale.jl
@@ -13,7 +13,7 @@ end
 
 Base.show(io::IO, μ::ScaledMeasure) = print(io, exp(μ.logscale), " * ", μ.base)
 
-function Base.show_unquoted(io::IO, μ::ProductMeasure, indent::Int, prec::Int)
+function Base.show_unquoted(io::IO, μ::ScaledMeasure, indent::Int, prec::Int)
     if Base.operator_precedence(:*) ≤ prec
         print(io, "(")
         show(io, μ)

--- a/src/combinators/scale.jl
+++ b/src/combinators/scale.jl
@@ -11,6 +11,8 @@ struct ScaledMeasure{R,M} <: AbstractMeasure
     base :: M
 end
 
+Base.show(io::IO, μ::ScaledMeasure) = print(io, "(", exp(μ.logscale), " * ", μ.base, ")")
+
 function logdensity(sm::ScaledMeasure{R,M}, x::X) where {X, R, M <: AbstractMeasure}
     logdensity(sm.base, x) + sm.logscale
 end

--- a/src/combinators/scale.jl
+++ b/src/combinators/scale.jl
@@ -11,7 +11,18 @@ struct ScaledMeasure{R,M} <: AbstractMeasure
     base :: M
 end
 
-Base.show(io::IO, μ::ScaledMeasure) = print(io, "(", exp(μ.logscale), " * ", μ.base, ")")
+Base.show(io::IO, μ::ScaledMeasure) = print(io, exp(μ.logscale), " * ", μ.base)
+
+function Base.show_unquoted(io::IO, μ::ProductMeasure, indent::Int, prec::Int)
+    if Base.operator_precedence(:*) ≤ prec
+        print(io, "(")
+        show(io, μ)
+        print(io, ")")
+    else
+        show(io, μ)
+    end
+    return nothing
+end
 
 function logdensity(sm::ScaledMeasure{R,M}, x::X) where {X, R, M <: AbstractMeasure}
     logdensity(sm.base, x) + sm.logscale

--- a/src/probability/normal.jl
+++ b/src/probability/normal.jl
@@ -7,7 +7,7 @@ export Normal
 import Base: eltype
 
 
-@measure Normal(μ,σ) ≃ (1/sqrt2π) * Lebesgue(X)
+@measure Normal(μ,σ) ≃ (1/sqrt2π) * Lebesgue(Real)
 
 
 function logdensity(d::Normal{P} , x::X) where {P <: NamedTuple{(:μ, :σ)}, X}    


### PR DESCRIPTION
I've added some. So now, e.g.,

```julia
julia> basemeasure(Normal()^3)
(0.39894228040143265 * Lebesgue(Real)) ^ (3,)

julia> basemeasure(Normal()*Normal())
(0.39894228040143265 * Lebesgue(Real)) ⊗ (0.39894228040143265 * Lebesgue(Real))
```