### PR TITLE
Disambiguate Product constructor

### DIFF
--- a/src/combinators/product.jl
+++ b/src/combinators/product.jl
@@ -32,6 +32,10 @@ end
 
 Base.length(m::ProductMeasure{T}) where {T} = length(m.data)
 
+function Base.:*(μ::ProductMeasure{Tuple{}}, ν::N) where {X, N <: AbstractMeasure}
+    ProductMeasure((ν,))
+end
+
 function Base.:*(μ::ProductMeasure{X}, ν::ProductMeasure{Y}) where {X,Y}
     data = (μ.data..., ν.data...)
     ProductMeasure(data...)


### PR DESCRIPTION
If the argument to the constructor `ProductMeasure(data...)` has only one element the meaning of the argument changes. This prevents from starting accumulation of a product measure with an empty product
```
acc = ProductMeasure(())
...
white ...
    acc = acc*ν
end
```