### PR TITLE
drop some Ts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureTheory"
 uuid = "eadaa1a4-d27c-401d-8699-e962e1bbc33b"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -28,7 +28,7 @@ mapcall(t, x) = map(func -> func(x), t)
 
 export kernelize
 
-function kernelize(μ::M) where {N, T, M <: ParameterizedMeasure{N,T}}
+function kernelize(μ::M) where {N, T, M <: ParameterizedMeasure{N}}
     C = M.name.wrapper
     (kernel(NamedTuple{N}, C), values(getfield(μ, :par)))
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -43,7 +43,7 @@ end
 function _measure(expr)
     @capture $μ($(p...)) expr begin
         q = quote
-            struct $μ{N,T} <: ParameterizedMeasure{N,T}
+            struct $μ{N,T} <: ParameterizedMeasure{N}
                 par :: NamedTuple{N,T}
             end
 
@@ -156,7 +156,7 @@ function _half(ex)
             quote
                 export $halfdist
                 
-                struct $halfdist{N,T} <: ParameterizedMeasure{N,T}
+                struct $halfdist{N,T} <: ParameterizedMeasure{N}
                     par :: NamedTuple{N,T}
                 end
                 

--- a/src/parameterized.jl
+++ b/src/parameterized.jl
@@ -1,21 +1,21 @@
 using TransformVariables
 
 export ParameterizedMeasure
-abstract type ParameterizedMeasure{N,T} <: AbstractMeasure end
+abstract type ParameterizedMeasure{N} <: AbstractMeasure end
 
-function Base.getproperty(μ::ParameterizedMeasure{N,T}, prop::Symbol) where {N,T}
+function Base.getproperty(μ::ParameterizedMeasure{N}, prop::Symbol) where {N}
     return getproperty(getfield(μ, :par), prop)
 end
 
-function Base.propertynames(μ::ParameterizedMeasure{N,T}) where {N,T}
+function Base.propertynames(μ::ParameterizedMeasure{N}) where {N}
     return N
 end
 
-function Base.show(io::IO, μ::ParameterizedMeasure{(),Tuple{}}) 
+function Base.show(io::IO, μ::ParameterizedMeasure{()}) 
     print(io, nameof(typeof(μ)), "()")
 end
 
-function Base.show(io::IO, μ::ParameterizedMeasure{N,T}) where {N,T}
+function Base.show(io::IO, μ::ParameterizedMeasure{N}) where {N}
     io = IOContext(io, :compact => true)
     print(io, nameof(typeof(μ)))
     print(io, getfield(μ,:par))

--- a/src/probability/LKJL.jl
+++ b/src/probability/LKJL.jl
@@ -20,7 +20,7 @@ correction of the transformation.
 Adapted from
 https://github.com/tpapp/AltDistributions.jl
 """
-struct LKJL{k, N, T} <: ParameterizedMeasure{N,T}
+struct LKJL{k, N, T} <: ParameterizedMeasure{N}
     par :: NamedTuple{N,T}
 end
 

--- a/src/probability/mvnormal.jl
+++ b/src/probability/mvnormal.jl
@@ -9,7 +9,7 @@ import Base
 
 
 
-struct MvNormal{N, T, I, J} <: ParameterizedMeasure{N, T}
+struct MvNormal{N, T, I, J} <: ParameterizedMeasure{N}
     par::NamedTuple{N, T}
 end
 


### PR DESCRIPTION
Currently we have
```julia
ParameterizedMeasure{N,T}
```

But... we never really use the T. It also prevents Soss models from being `<: ParameterizedMeasure`, because we don't know the parameter types for them until they're passed