### PR TITLE
remove test failure if warnings are printed when package is imported

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,7 @@ using Random
 using LinearAlgebra
 using DynamicIterators: trace, TimeLift
 using TransformVariables: transform, as𝕀, inverse
-
-if Base.VERSION ≥ v"1.6"
-    @testset "No warnings on import" begin
-        @test_nowarn @eval using MeasureTheory
-    end
-else
-    @eval using MeasureTheory
-end
+using MeasureTheory
 
 function draw2(μ)
     x = rand(μ)


### PR DESCRIPTION
This is a very brittle test, if any of the dependencies shows something to stderr this will fail. On 1.7 this happens (https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/9bb1633_vs_dd12291/MeasureTheory.1.7.0-beta2-9a791aa09fb.log). For example:

```
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead
```

I would say this test needs to be more precise if it is to be useful.