### PR TITLE
Categorical distribution

### DIFF
--- a/src/parameterized/categorical.jl
+++ b/src/parameterized/categorical.jl
@@ -1,0 +1,27 @@
+# Categorical distribution
+
+# REFERENCES
+# https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Categorical
+# https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.DiscreteNonParametric
+
+export Categorical
+
+@parameterized Categorical(p) ≪ CountingMeasure(ℤ[0:∞])
+
+ncategories(d::Categorical) = length(d.p)
+
+(d::Categorical ≪ ::CountingMeasure{IntegerRange{a,b}}) where {a,b} = a ≤ 1 && b ≥ ncategories(d)
+
+(::CountingMeasure{IntegerRange{a,b}} ≪ ::Categorical) where {a,b} = a ≥ 1 && b ≤ ncategories(d)
+
+###############################################################################
+@kwstruct Categorical(p)
+
+logdensity(d::Categorical{(:p)}, y) = log(d.p[y])
+
+# Very inefficient because of the heavy implementation of Dists.DiscreteNonParametric
+distproxy(d::Categorical{(:p)}) = Dists.Categorical(d.p)
+
+Base.rand(rng::AbstractRNG, T::Type, d::Categorical{(:p)}) = rand(rng, distproxy(d))
+
+asparams(::Type{<:Categorical}, ::Val{:p}) = as𝕀

--- a/src/parameterized/categorical.jl
+++ b/src/parameterized/categorical.jl
@@ -19,9 +19,22 @@ ncategories(d::Categorical) = length(d.p)
 
 logdensity(d::Categorical{(:p)}, y) = log(d.p[y])
 
-# Very inefficient because of the heavy implementation of Dists.DiscreteNonParametric
+# The implementation of Dists.DiscreteNonParametric has heavy argument checks
+# But I think since the values of Categorical are 1:n the sortperm has no effect
+# So it might be OK
 distproxy(d::Categorical{(:p)}) = Dists.Categorical(d.p)
 
 Base.rand(rng::AbstractRNG, T::Type, d::Categorical{(:p)}) = rand(rng, distproxy(d))
 
 asparams(::Type{<:Categorical}, ::Val{:p}) = as𝕀
+
+###############################################################################
+@kwstruct Categorical(logp)
+
+logdensity(d::Categorical{(:logp)}, y) = d.logp[y]
+
+distproxy(d::Categorical{(:logp)}) = Dists.Categorical(exp.(d.logp))  # inefficient
+
+Base.rand(rng::AbstractRNG, T::Type, d::Categorical{(:logp)}) = rand(rng, distproxy(d))
+
+asparams(::Type{<:Categorical}, ::Val{:logp}) = asℝ


### PR DESCRIPTION
Partially solves #145. I did not add alternative (log-p) parametrizations yet.
I think this one is a typical example of the limits of our approach, which was to default on Distributions.jl for sampling and other things whenever possible. Indeed, their implementation of `Categorical` relies on `DiscreteNonParametric`, which is a nightmare in terms of efficiency (see [here](https://github.com/JuliaStats/Distributions.jl/blob/2856bc3e106d751a02e3fe9cccb046916a52955e/src/univariate/discrete/discretenonparametric.jl#L30) for the worst part). 
In my opinion, this boils down to their library being "safe" whereas we over at MeasureTheory.jl choose to trust that the user will avoid nonsensical inputs.