### PR TITLE
Update MvNormal

### DIFF
--- a/src/parameterized/mvnormal.jl
+++ b/src/parameterized/mvnormal.jl
@@ -14,7 +14,7 @@ function MvNormal(nt::NamedTuple{(:σ,)})
 end
 
 function MvNormal(nt::NamedTuple{(:ω,)})
-    dim = size(nt.σ, 1)
+    dim = size(nt.ω, 1)
     Affine(nt, Normal() ^ dim)
 end
 
@@ -24,6 +24,6 @@ function MvNormal(nt::NamedTuple{(:μ, :σ,)})
 end
 
 function MvNormal(nt::NamedTuple{(:μ, :ω,)})
-    dim = size(nt.σ, 1)
+    dim = size(nt.ω, 1)
     Affine(nt, Normal() ^ dim)
 end


### PR DESCRIPTION
This PR makes simplifications to `MvNormal`, based on the new `Affine` constructor in MeasureBase