### PR TITLE
Add a `Uniform(a, b)` measure

### DIFF
--- a/src/parameterized/uniform.jl
+++ b/src/parameterized/uniform.jl
@@ -64,6 +64,6 @@ end
 
 distproxy(d::Uniform{(:shift, :scale)}) = Dists.Uniform(d.shift, d.shift + d.scale)
 
-TV.as(d::Uniform{(:shift, :scale), T}) where T = TV.ScaledShiftedLogistic(Real, d.scale, d.shift)
+TV.as(d::Uniform{(:shift, :scale)}) = TV.ScaledShiftedLogistic(d.scale, d.shift)
 
 Base.rand(rng::AbstractRNG, T::Type, μ::Uniform{(:shift, :scale)}) = rand(rng, T)*μ.scale + μ.shift

--- a/src/parameterized/uniform.jl
+++ b/src/parameterized/uniform.jl
@@ -28,3 +28,40 @@ Base.rand(rng::AbstractRNG, T::Type, μ::Uniform{()}) = rand(rng, T)
 
 ###############################################################################
 # Uniform
+#
+# The parameterization was chosen to enforce the constraint that the parameters
+# define an interval. Since `asparams` operates on parameters independently,
+# we parameterize with the left point of the interval (lower bound) and the width
+# of the interval, which is parameterized as positive real number (`asℝ₊`).
+
+@kwstruct Uniform(left, width)
+
+function basemeasure(d::Uniform{(:left, :width)})
+    # Lebesgue measure on (left, width+left)
+    lb = d.left
+    ub = d.left + d.width
+    inbounds(x) = lb < x < ub
+    constℓ = 0.0
+    varℓ() = 0.0
+    base = Lebesgue(ℝ)
+    FactoredBase(inbounds, constℓ, varℓ, base)
+end
+
+asparams(::Type{<:Uniform{(:left, :width)}}, ::Val{:left}) = asℝ
+asparams(::Type{<:Uniform{(:left, :width)}}, ::Val{:width}) = asℝ₊
+
+"""
+The uniform probability measure on the interval (a, b).
+"""
+function Uniform(a, b)
+    @assert(a < b)
+    Uniform(left=a, width=b-a)
+end
+
+logdensity(d::Uniform{(:left, :width)}, x) = -log(d.width)
+
+distproxy(d::Uniform{(:left, :width)}) = Dists.Uniform(d.left, d.left + d.width)
+
+TV.as(d::Uniform{(:left, :width), T}) where T = TV.as(Real, d.left, d.left + d.width)
+
+Base.rand(rng::AbstractRNG, T::Type, μ::Uniform{(:left, :width)}) = rand(rng, T)*μ.width + μ.left

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ test_measures = [
     Poisson(3.1)
     StudentT(ν=2.1)    
     Uniform()
+    Uniform(-1.0, 1.0)
     Normal() ⊙ Cauchy()
     Dirac(0.0) + Normal()
 ]


### PR DESCRIPTION
This PR adds a parameterized uniform measure on an interval `(a, b)`.