### PR TITLE
Fix cdf and univariate affine broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureTheory"
 uuid = "eadaa1a4-d27c-401d-8699-e962e1bbc33b"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.16.5"
+version = "0.16.6"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -339,7 +339,3 @@ end
 @inline function Distributions.cdf(d::Affine, x)
     cdf(parent(d), inverse(d.f)(x))
 end
-
-# @inline function Distributions.cdf.(d::Affine, x::AbstractArray)
-#     cdf.((parent(d),), inverse(d.f)(x))
-# end

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -348,6 +348,6 @@ end
     cdf(parent(d), inverse(d.f)(x))
 end
 
-@inline function Distributions.cdf(d::Affine, x::AbstractArray)
-    cdf.((parent(d),), inverse(d.f)(x))
-end
+# @inline function Distributions.cdf.(d::Affine, x::AbstractArray)
+#     cdf.((parent(d),), inverse(d.f)(x))
+# end

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -61,12 +61,12 @@ Base.size(f::AffineTransform, n::Int) = @inbounds size(f)[n]
 (f::AffineTransform{(:μ, :σ)})(x) = f.σ * x + f.μ
 (f::AffineTransform{(:μ, :λ)})(x) = f.λ \ x + f.μ
 
-# Vector `x` observations broadcasts, adjusted for univariate and multivariate cases
-(f::AffineTransform{(:μ,)})(x::AbstractArray) = supportdim(params(f)) == () ? x .+ f.μ : x .+ (f.μ,)
-(f::AffineTransform{(:σ,)})(x::AbstractArray) = supportdim(params(f)) == () ? f.σ .* x : (f.σ,) .* x
-(f::AffineTransform{(:λ,)})(x::AbstractArray) = supportdim(params(f)) == () ? f.λ .\ x : (f.λ,) \ x
-(f::AffineTransform{(:μ, :σ)})(x::AbstractArray) = supportdim(params(f)) == () ? f.σ .* x .+ f.μ : (f.σ,) * x + (f.μ,)
-(f::AffineTransform{(:μ, :λ)})(x::AbstractArray) = supportdim(params(f)) == () ? f.λ .\ x .+ f.μ : (f.λ,) \ x + (f.μ,)
+# Broadcast over vector `x` for univariate distributions
+(f::AffineTransform{(:μ,)})(x::AbstractArray) = supportdim(params(f)) == () ? x .+ f.μ : x + f.μ
+(f::AffineTransform{(:σ,)})(x::AbstractArray) = supportdim(params(f)) == () ? f.σ .* x : f.σ * x
+(f::AffineTransform{(:λ,)})(x::AbstractArray) = supportdim(params(f)) == () ? f.λ .\ x : f.λ \ x
+(f::AffineTransform{(:μ, :σ)})(x::AbstractArray) = supportdim(params(f)) == () ? f.σ .* x .+ f.μ : f.σ * x + f.μ
+(f::AffineTransform{(:μ, :λ)})(x::AbstractArray) = supportdim(params(f)) == () ? f.λ .\ x .+ f.μ : f.λ \ x + f.μ
 
 rowsize(x) = ()
 rowsize(x::AbstractArray) = (size(x, 1),)
@@ -346,4 +346,8 @@ end
 
 @inline function Distributions.cdf(d::Affine, x)
     cdf(parent(d), inverse(d.f)(x))
+end
+
+@inline function Distributions.cdf(d::Affine, x::AbstractArray)
+    cdf.((parent(d),), inverse(d.f)(x))
 end

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -337,5 +337,5 @@ end
 end
 
 @inline function Distributions.cdf(d::Affine, x)
-    cdf(parent(d), inverse(d.f)(x))
+    cdf(parent(d), inverse(d.f).(x))
 end

--- a/src/combinators/affine.jl
+++ b/src/combinators/affine.jl
@@ -54,19 +54,11 @@ end
 
 Base.size(f::AffineTransform, n::Int) = @inbounds size(f)[n]
 
-# Univariate case with single `x`` observation
 (f::AffineTransform{(:μ,)})(x) = x + f.μ
 (f::AffineTransform{(:σ,)})(x) = f.σ * x
 (f::AffineTransform{(:λ,)})(x) = f.λ \ x
 (f::AffineTransform{(:μ, :σ)})(x) = f.σ * x + f.μ
 (f::AffineTransform{(:μ, :λ)})(x) = f.λ \ x + f.μ
-
-# Broadcast over vector `x` for univariate distributions
-(f::AffineTransform{(:μ,)})(x::AbstractArray) = supportdim(params(f)) == () ? x .+ f.μ : x + f.μ
-(f::AffineTransform{(:σ,)})(x::AbstractArray) = supportdim(params(f)) == () ? f.σ .* x : f.σ * x
-(f::AffineTransform{(:λ,)})(x::AbstractArray) = supportdim(params(f)) == () ? f.λ .\ x : f.λ \ x
-(f::AffineTransform{(:μ, :σ)})(x::AbstractArray) = supportdim(params(f)) == () ? f.σ .* x .+ f.μ : f.σ * x + f.μ
-(f::AffineTransform{(:μ, :λ)})(x::AbstractArray) = supportdim(params(f)) == () ? f.λ .\ x .+ f.μ : f.λ \ x + f.μ
 
 rowsize(x) = ()
 rowsize(x::AbstractArray) = (size(x, 1),)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -645,3 +645,8 @@ end
     
     @test logdensityof(d, x) isa Real
 end
+
+@testset "Distributions.jl cdf" begin
+    @test cdf(Normal(0, 1), 0) == 0.5
+    @test cdf(Normal(0, 1), [0, 0]) == [0.5, 0.5]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -656,5 +656,5 @@ end
 
 @testset "Distributions.jl cdf" begin
     @test cdf(Normal(0, 1), 0) == 0.5
-    @test cdf(Normal(0, 1), [0, 0]) == [0.5, 0.5]
+    @test cdf.((Normal(0, 1),), [0, 0]) == [0.5, 0.5]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -575,10 +575,6 @@ end
     @test f(inverse(f)(1)) == 1
     @test inverse(f)(f(1)) == 1
 
-    f = AffineTransform((μ = 3,))
-    @test f(inverse(f)(1)) == 1
-    @test inverse(f)(f(1)) == 1
-
     f = AffineTransform((σ = [1 2; 2 1],))
     @test f(inverse(f)([1 2; 2 1])) == [1 2; 2 1]
     @test inverse(f)(f([1 2; 2 1])) == [1 2; 2 1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -574,6 +574,14 @@ end
     f = AffineTransform((μ = 3,))
     @test f(inverse(f)(1)) == 1
     @test inverse(f)(f(1)) == 1
+
+    f = AffineTransform((μ = 3,))
+    @test f(inverse(f)(1)) == 1
+    @test inverse(f)(f(1)) == 1
+
+    f = AffineTransform((σ = [1 2; 2 1],))
+    @test f(inverse(f)([1 2; 2 1])) == [1 2; 2 1]
+    @test inverse(f)(f([1 2; 2 1])) == [1 2; 2 1]
 end
 
 @testset "Affine" begin


### PR DESCRIPTION
Currently, the following code errors: 

```julia
cdf(MeasureTheory.Normal(37.5, 7.5), [10, 25])
```

Output:

```julia
MethodError: no method matching +(::Vector{Float64}, ::Float64)
For element-wise addition, use broadcasting with dot syntax: array .+ scalar
Closest candidates are:
+(::Any, ::Any, !Matched::Any, !Matched::Any...)
@ Base operators.jl:578
+(!Matched::T, ::T) where T<:Union{Float16, Float32, Float64}
@ Base float.jl:383
+(!Matched::Union{InitialValues.NonspecificInitialValue, InitialValues.SpecificInitialValue{typeof(+)}}, ::Any)
@ InitialValues ~/.julia/packages/InitialValues/OWP8V/src/InitialValues.jl:154
...
(::MeasureTheory.AffineTransform{(:μ, :λ), Tuple{Float64, Float64}})(::Vector{Int64})@affine.jl:61
cdf@affine.jl:340[inlined]
cdf(::MeasureTheory.Normal{(:μ, :σ), Tuple{Float64, Float64}}, ::Vector{Int64})@distproxy.jl:45
top-level scope@[Local: 1](http://localhost:1234/edit?id=1ffc8736-1004-11ed-3766-0df61498ed70#)[inlined]
```