### PR TITLE
LebesgueMeasure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureTheory"
 uuid = "eadaa1a4-d27c-401d-8699-e962e1bbc33b"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.17.2"
+version = "0.18.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/parameterized/beta.jl
+++ b/src/parameterized/beta.jl
@@ -21,7 +21,7 @@ end
 
 @inline function basemeasure(d::Beta{(:α, :β)})
     ℓ = -logbeta(d.α, d.β)
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end
 
 Base.rand(rng::AbstractRNG, T::Type, μ::Beta) = rand(rng, Dists.Beta(μ.α, μ.β))

--- a/src/parameterized/cauchy.jl
+++ b/src/parameterized/cauchy.jl
@@ -14,7 +14,7 @@ export Cauchy, HalfCauchy
 
 logdensity_def(d::Cauchy, x) = logdensity_def(proxy(d), x)
 
-basemeasure(d::Cauchy) = WeightedMeasure(static(-logπ), Lebesgue(ℝ))
+basemeasure(d::Cauchy) = WeightedMeasure(static(-logπ), LebesgueMeasure())
 
 # @affinepars Cauchy
 

--- a/src/parameterized/exponential.jl
+++ b/src/parameterized/exponential.jl
@@ -6,7 +6,7 @@ export Exponential
 @parameterized Exponential(β)
 
 insupport(::Exponential, x) = x ≥ 0
-basemeasure(::Exponential) = Lebesgue()
+basemeasure(::Exponential) = LebesgueMeasure()
 
 @kwstruct Exponential()
 

--- a/src/parameterized/gamma.jl
+++ b/src/parameterized/gamma.jl
@@ -19,7 +19,7 @@ end
 
 function basemeasure(d::Gamma{(:k,)})
     ℓ = -loggamma(d.k)
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end
 
 @kwstruct Gamma(k, σ)
@@ -57,11 +57,11 @@ function basemeasure(d::Gamma{(:μ, :ϕ)})
     ϕ = d.ϕ
     ϕinv = inv(ϕ)
     ℓ = -ϕinv * log(ϕ) - first(logabsgamma(ϕinv))
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end
 
 function basemeasure(d::Gamma{(:μ, :ϕ),Tuple{M,StaticFloat64{ϕ}}}) where {M,ϕ}
     ϕinv = inv(ϕ)
     ℓ = static(-ϕinv * log(ϕ) - first(logabsgamma(ϕinv)))
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end

--- a/src/parameterized/gumbel.jl
+++ b/src/parameterized/gumbel.jl
@@ -4,7 +4,7 @@ export Gumbel
 
 @parameterized Gumbel()
 
-basemeasure(::Gumbel{()}) = Lebesgue(ℝ)
+basemeasure(::Gumbel{()}) = LebesgueMeasure()
 
 @kwstruct Gumbel()
 

--- a/src/parameterized/inverse-gaussian.jl
+++ b/src/parameterized/inverse-gaussian.jl
@@ -49,5 +49,5 @@ end
 
 function basemeasure(d::InverseGaussian{(:μ, :ϕ)})
     ℓ = static(-0.5) * (static(float(log2π)) + log(d.ϕ))
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end

--- a/src/parameterized/laplace.jl
+++ b/src/parameterized/laplace.jl
@@ -27,7 +27,7 @@ end
 
 logdensity_def(d::Laplace, x) = logdensity_def(proxy(d), x)
 
-basemeasure(::Laplace{()}) = WeightedMeasure(static(-logtwo), Lebesgue(ℝ))
+basemeasure(::Laplace{()}) = WeightedMeasure(static(-logtwo), LebesgueMeasure())
 
 # @affinepars Laplace
 

--- a/src/parameterized/lkj-cholesky.jl
+++ b/src/parameterized/lkj-cholesky.jl
@@ -81,14 +81,14 @@ as(d::LKJCholesky) = CorrCholesky(d.k)
 
 @inline function basemeasure(d::LKJCholesky{(:k, :η)})
     t = as(d)
-    base = Pushforward(t, Lebesgue(ℝ)^TV.dimension(t), False())
+    base = Pushforward(t, LebesgueMeasure()^TV.dimension(t), False())
     WeightedMeasure(Dists.lkj_logc0(d.k, d.η), base)
 end
 
 @inline function basemeasure(d::LKJCholesky{(:k, :logη)})
     t = as(d)
     η = exp(d.logη)
-    base = Pushforward(t, Lebesgue(ℝ)^TV.dimension(t), False())
+    base = Pushforward(t, LebesgueMeasure()^TV.dimension(t), False())
     WeightedMeasure(Dists.lkj_logc0(d.k, η), base)
 end
 

--- a/src/parameterized/normal.jl
+++ b/src/parameterized/normal.jl
@@ -37,7 +37,7 @@ insupport(d::Normal, x) = true
 insupport(d::Normal) = Returns(true)
 
 @inline logdensity_def(d::Normal{()}, x) = -x^2 / 2
-@inline basemeasure(::Normal{()}) = WeightedMeasure(static(-0.5 * log2π), Lebesgue(ℝ))
+@inline basemeasure(::Normal{()}) = WeightedMeasure(static(-0.5 * log2π), LebesgueMeasure())
 
 @kwstruct Normal(μ)
 @kwstruct Normal(σ)

--- a/src/parameterized/normal.jl
+++ b/src/parameterized/normal.jl
@@ -147,7 +147,7 @@ end
 
 @inline function basemeasure(d::Normal{(:σ²,)})
     ℓ = static(-0.5) * (static(float(log2π)) + log(d.σ²))
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end
 
 proxy(d::Normal{(:μ, :σ²)}) = affine((μ = d.μ,), Normal((σ² = d.σ²,)))

--- a/src/parameterized/snedecorf.jl
+++ b/src/parameterized/snedecorf.jl
@@ -16,7 +16,7 @@ end
 
 @inline function basemeasure(d::SnedecorF{(:ν1, :ν2)})
     ℓ = -logbeta(d.ν1 / 2, d.ν2 / 2)
-    weightedmeasure(ℓ, Lebesgue())
+    weightedmeasure(ℓ, LebesgueMeasure())
 end
 
 xform(::SnedecorF) = asℝ₊

--- a/src/parameterized/studentt.jl
+++ b/src/parameterized/studentt.jl
@@ -50,7 +50,7 @@ end
 
 @inline function basemeasure(d::StudentT{(:ν,)})
     ℓ = loggamma((d.ν + 1) / 2) - loggamma(d.ν / 2) - log(π * d.ν) / 2
-    weightedmeasure(ℓ, Lebesgue(ℝ))
+    weightedmeasure(ℓ, LebesgueMeasure())
 end
 
 xform(::StudentT) = asℝ

--- a/src/parameterized/uniform.jl
+++ b/src/parameterized/uniform.jl
@@ -13,7 +13,7 @@ export Uniform
 insupport(::Uniform{()}) = in𝕀
 insupport(::Uniform{()}, x) = in𝕀(x)
 
-@inline basemeasure(::Uniform{()}) = Lebesgue(ℝ)
+@inline basemeasure(::Uniform{()}) = LebesgueMeasure()
 
 proxy(::Uniform{()}) = Dists.Uniform()
 


### PR DESCRIPTION
MeasureTheory has both `Lebesgue` and `LebesgueMeasure`. The roles of these need to be made more clear.

I think `LebesgueMeasure` should be the primitive measure on $\mathbb{R}$, and `Lebesgue` should be a convenience for representing Lebesgue measure that's either restricted or over some different space. 

For example, `Lebesgue(𝕀)` is Lebesgue measure on the unit interval, and `Lebesgue(Simplex())` is Lebesgue measure on a simplex (to be used as a base measure for Dirichlet).

In this way, users defining a new space `S` can define the behavior of `Lebesgue{S}`.