### PR TITLE
add method for Distributions.rand(::ResettableRNG, ::Binomial)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MeasureTheory"
 uuid = "eadaa1a4-d27c-401d-8699-e962e1bbc33b"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.18.1"
+version = "0.18.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/parameterized/binomial.jl
+++ b/src/parameterized/binomial.jl
@@ -23,15 +23,11 @@ end
     x ∈ (0, 1)
 end
 
-function Base.rand(rng::AbstractRNG, ::Type, d::Binomial{(:n, :p)})
-    rand(rng, Dists.Binomial(d.n, d.p))
+function Base.rand(rng::AbstractRNG, ::Type{T}, d::Binomial{(:n, :p)}) where {T}
+    rand(rng, T, Dists.Binomial(d.n, d.p))
 end
 
 Binomial(n) = Binomial(n, 0.5)
-
-function Dists.rand(rng::ResettableRNG, d::Dists.Binomial)
-    rand(rng.rng, d)
-end
 
 ###############################################################################
 @kwstruct Binomial(n, p)

--- a/src/parameterized/binomial.jl
+++ b/src/parameterized/binomial.jl
@@ -29,6 +29,10 @@ end
 
 Binomial(n) = Binomial(n, 0.5)
 
+function Dists.rand(rng::ResettableRNG, d::Dists.Binomial)
+    rand(rng.rng, d)
+end
+
 ###############################################################################
 @kwstruct Binomial(n, p)
 

--- a/src/resettable-rng.jl
+++ b/src/resettable-rng.jl
@@ -57,6 +57,14 @@ for T in vcat(subtypes(Signed), subtypes(Unsigned), subtypes(AbstractFloat))
     end
 end
 
+function Base.rand(r::ResettableRNG, d::AbstractMeasure)
+    rand(r.rng, d)
+end
+
+function Base.rand(r::ResettableRNG, ::Type{T}, d::AbstractMeasure) where {T}
+    rand(r.rng, T, d)
+end
+
 Base.iterate(r::ResettableRNG) = iterate(r, nothing)
 
 function Base.iterate(r::ResettableRNG, ::Nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,7 +116,7 @@ end
         @test ℓ ≈ logdensity_def(Binomial(; n, logitp), y)
         @test ℓ ≈ logdensity_def(Binomial(; n, probitp), y)
 
-        rng = ResettableRNG(Random.Xoshiro())
+        rng = ResettableRNG(Random.MersenneTwister())
         @test rand(rng, Binomial(n=0, p=1.0)) == 0
         @test rand(rng, Binomial(n=10, p=1.0)) == 10
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,10 @@ end
         @test ℓ ≈ logdensity_def(Binomial(; n, logitp), y)
         @test ℓ ≈ logdensity_def(Binomial(; n, probitp), y)
 
+        rng = ResettableRNG(Random.Xoshiro())
+        @test rand(rng, Binomial(n=0, p=1.0)) == 0
+        @test rand(rng, Binomial(n=10, p=1.0)) == 10
+
         @test_broken logdensity_def(Binomial(n, p), CountingMeasure(ℤ[0:n]), x) ≈
                      binomlogpdf(n, p, x)
     end


### PR DESCRIPTION
This should address #248, which actually didn't have anything to do with product measure, but rather a method for the Binomial distribution. Also added a test to check for this behavior; it would fail previously.